### PR TITLE
Improve performance by using FadeTransition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### [2.0.1] - Performance improvements
+* Fade-ins and fade-outs use FadeTransition instead of Opacity now.
+
 #### [2.0.0] - Null-safety
 * Now Animate_do its a library
 * Null-safety checked and passed

--- a/lib/src/animate_do_attention_seekers.dart
+++ b/lib/src/animate_do_attention_seekers.dart
@@ -197,6 +197,7 @@ class _FlashState extends State<Flash> with SingleTickerProviderStateMixin {
     return AnimatedBuilder(
         animation: controller!,
         builder: (BuildContext context, Widget? child) {
+          // TODO: refactor into FadeTransition for performance improvement
           return Opacity(
               opacity: (controller!.value < 0.25)
                   ? opacityOut1.value

--- a/lib/src/animate_do_bounces.dart
+++ b/lib/src/animate_do_bounces.dart
@@ -88,7 +88,7 @@ class _BounceInDownState extends State<BounceInDown>
         builder: (BuildContext context, Widget? child) {
           return Transform.translate(
               offset: Offset(0, animation.value),
-              child: Opacity(opacity: opacity.value, child: widget.child));
+              child: FadeTransition(opacity: opacity, child: widget.child));
         });
   }
 }
@@ -226,8 +226,8 @@ class _BounceInLeftState extends State<BounceInLeft>
         builder: (BuildContext context, Widget? child) {
           return Transform.translate(
               offset: Offset(animation.value, 0),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });

--- a/lib/src/animate_do_elastics.dart
+++ b/lib/src/animate_do_elastics.dart
@@ -86,8 +86,8 @@ class _ElasticInState extends State<ElasticIn>
         builder: (BuildContext context, Widget? child) {
           return Transform.scale(
             scale: bouncing.value,
-            child: Opacity(
-              opacity: opacity.value,
+            child: FadeTransition(
+              opacity: opacity,
               child: widget.child,
             ),
           );
@@ -197,8 +197,8 @@ class _ElasticInDownState extends State<ElasticInDown>
                   (falling.value == (widget.to * -1))
                       ? bouncing.value
                       : falling.value),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });
@@ -354,8 +354,8 @@ class _ElasticInLeftState extends State<ElasticInLeft>
                       ? bouncing.value
                       : falling.value,
                   0),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });

--- a/lib/src/animate_do_fadeouts.dart
+++ b/lib/src/animate_do_fadeouts.dart
@@ -76,14 +76,10 @@ class _FadeOutState extends State<FadeOut> with SingleTickerProviderStateMixin {
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: animation,
-        builder: (BuildContext context, Widget? child) {
-          return Opacity(
-            opacity: animation.value,
-            child: widget.child,
-          );
-        });
+    return FadeTransition(
+      opacity: animation,
+      child: widget.child,
+    );
   }
 }
 
@@ -130,7 +126,7 @@ class _FadeOutDownState extends State<FadeOutDown>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
 
   @override
@@ -146,7 +142,7 @@ class _FadeOutDownState extends State<FadeOutDown>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: 0, end: widget.from)
+    animation = Tween<Offset>(begin: Offset.zero, end: Offset(0, widget.from))
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
 
     opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
@@ -171,16 +167,13 @@ class _FadeOutDownState extends State<FadeOutDown>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(0, animation.value),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 
@@ -273,7 +266,7 @@ class _FadeOutUpState extends State<FadeOutUp>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
   @override
   void dispose() {
@@ -288,7 +281,8 @@ class _FadeOutUpState extends State<FadeOutUp>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: 0.0, end: widget.from * -1)
+    animation = Tween<Offset>(
+            begin: Offset.zero, end: Offset(0, widget.from * -1))
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
     opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
         CurvedAnimation(parent: controller!, curve: Interval(0, 0.65)));
@@ -312,16 +306,13 @@ class _FadeOutUpState extends State<FadeOutUp>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(0, animation.value),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 
@@ -414,7 +405,7 @@ class _FadeOutLeftState extends State<FadeOutLeft>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
   @override
   void dispose() {
@@ -429,7 +420,8 @@ class _FadeOutLeftState extends State<FadeOutLeft>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: 0, end: widget.from * -1)
+    animation = Tween<Offset>(
+            begin: Offset.zero, end: Offset(widget.from * -1, 0))
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
     opacity = Tween<double>(begin: 1.0, end: 0.0).animate(
         CurvedAnimation(parent: controller!, curve: Interval(0, 0.65)));
@@ -453,16 +445,13 @@ class _FadeOutLeftState extends State<FadeOutLeft>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(animation.value, 0),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 

--- a/lib/src/animate_do_fades.dart
+++ b/lib/src/animate_do_fades.dart
@@ -77,14 +77,10 @@ class _FadeInState extends State<FadeIn> with SingleTickerProviderStateMixin {
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: animation,
-        builder: (BuildContext context, Widget? child) {
-          return Opacity(
-            opacity: animation.value,
-            child: widget.child,
-          );
-        });
+    return FadeTransition(
+      opacity: animation,
+      child: widget.child,
+    );
   }
 }
 
@@ -132,7 +128,7 @@ class _FadeInDownState extends State<FadeInDown>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
 
   @override
@@ -148,7 +144,8 @@ class _FadeInDownState extends State<FadeInDown>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: widget.from * -1, end: 0)
+    animation = Tween<Offset>(
+            begin: Offset(0, widget.from * -1), end: Offset.zero)
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
 
     opacity = Tween<double>(begin: 0, end: 1).animate(
@@ -173,16 +170,13 @@ class _FadeInDownState extends State<FadeInDown>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(0, animation.value),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 
@@ -275,7 +269,7 @@ class _FadeInUpState extends State<FadeInUp>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
   @override
   void dispose() {
@@ -290,7 +284,7 @@ class _FadeInUpState extends State<FadeInUp>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: widget.from, end: 0)
+    animation = Tween<Offset>(begin: Offset(0, widget.from), end: Offset.zero)
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
     opacity = Tween<double>(begin: 0, end: 1).animate(
         CurvedAnimation(parent: controller!, curve: Interval(0, 0.65)));
@@ -314,16 +308,13 @@ class _FadeInUpState extends State<FadeInUp>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(0, animation.value),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 
@@ -417,7 +408,7 @@ class _FadeInLeftState extends State<FadeInLeft>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
   @override
   void dispose() {
@@ -432,7 +423,8 @@ class _FadeInLeftState extends State<FadeInLeft>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: widget.from * -1, end: 0)
+    animation = Tween<Offset>(
+            begin: Offset(widget.from * -1, 0), end: Offset.zero)
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
     opacity = Tween<double>(begin: 0, end: 1).animate(
         CurvedAnimation(parent: controller!, curve: Interval(0, 0.65)));
@@ -456,16 +448,13 @@ class _FadeInLeftState extends State<FadeInLeft>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(animation.value, 0),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 
@@ -559,7 +548,7 @@ class _FadeInRightState extends State<FadeInRight>
     with SingleTickerProviderStateMixin {
   AnimationController? controller;
   bool disposed = false;
-  late Animation<double> animation;
+  late Animation<Offset> animation;
   late Animation<double> opacity;
   @override
   void dispose() {
@@ -574,7 +563,7 @@ class _FadeInRightState extends State<FadeInRight>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animation = Tween<double>(begin: widget.from, end: 0)
+    animation = Tween<Offset>(begin: Offset(widget.from, 0), end: Offset.zero)
         .animate(CurvedAnimation(parent: controller!, curve: Curves.easeOut));
     opacity = Tween<double>(begin: 0, end: 1).animate(
         CurvedAnimation(parent: controller!, curve: Interval(0, 0.65)));
@@ -598,16 +587,13 @@ class _FadeInRightState extends State<FadeInRight>
       controller?.forward();
     }
 
-    return AnimatedBuilder(
-        animation: controller!,
-        builder: (BuildContext context, Widget? child) {
-          return Transform.translate(
-              offset: Offset(animation.value, 0),
-              child: Opacity(
-                opacity: opacity.value,
-                child: widget.child,
-              ));
-        });
+    return SlideTransition(
+      position: animation,
+      child: FadeTransition(
+        opacity: opacity,
+        child: widget.child,
+      ),
+    );
   }
 }
 

--- a/lib/src/animate_do_flips.dart
+++ b/lib/src/animate_do_flips.dart
@@ -87,8 +87,8 @@ class _FlipInXState extends State<FlipInX> with SingleTickerProviderStateMixin {
           return Transform(
               alignment: FractionalOffset.center,
               transform: Matrix4.identity()..rotateX(rotation.value),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });
@@ -182,8 +182,8 @@ class _FlipInYState extends State<FlipInY> with SingleTickerProviderStateMixin {
           return Transform(
               alignment: FractionalOffset.center,
               transform: Matrix4.identity()..rotateY(rotation.value),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });

--- a/lib/src/animate_do_specials.dart
+++ b/lib/src/animate_do_specials.dart
@@ -89,8 +89,8 @@ class _JelloInState extends State<JelloIn> with SingleTickerProviderStateMixin {
               transform: Matrix4.identity()
                 ..setEntry(0, 0, rotation.value + 1)
                 ..rotateX(rotation.value),
-              child: Opacity(
-                opacity: opacity.value,
+              child: FadeTransition(
+                opacity: opacity,
                 child: widget.child,
               ));
         });

--- a/lib/src/animate_do_zooms.dart
+++ b/lib/src/animate_do_zooms.dart
@@ -87,8 +87,8 @@ class _ZoomInState extends State<ZoomIn> with SingleTickerProviderStateMixin {
         builder: (BuildContext context, Widget? child) {
           return Transform.scale(
             scale: fade.value,
-            child: Opacity(
-              opacity: opacity.value,
+            child: FadeTransition(
+              opacity: opacity,
               child: widget.child,
             ),
           );
@@ -184,8 +184,8 @@ class _ZoomOutState extends State<ZoomOut> with SingleTickerProviderStateMixin {
         builder: (BuildContext context, Widget? child) {
           return Transform.scale(
             scale: zoom.value,
-            child: Opacity(
-              opacity: opacity.value,
+            child: FadeTransition(
+              opacity: opacity,
               child: widget.child,
             ),
           );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animate_do
 description: Beautiful animations inspired on Animate.css, every animation is a widget that contains default but customizable values that look attractive.
-version: 2.0.0
+version: 2.0.1
 homepage: https://fernando-herrera.com
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: animate_do
 description: Beautiful animations inspired on Animate.css, every animation is a widget that contains default but customizable values that look attractive.
 version: 2.0.1
 homepage: https://fernando-herrera.com
+repository: https://github.com/Klerith/animate_do_package
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
When changing opacity in animations, it is much more performant to use FadeTransition instead of a re-building Opacity. See “Performance considerations for opacity animation” in https://api.flutter.dev/flutter/widgets/Opacity-class.html.

I also made changes to animate_do_fades and animate_do_fadeouts to use SlideTransition instead of Transform.translate. This lets us get rid of AnimatedBuilder altogether.

This could be replicated in other files as well, but I ran out of time.