### PR TITLE
Fix: RubberBand missing 'infinite' support (Attention Seekers) / Corrección: Soporte 'infinite' faltante en RubberBand

### DIFF
--- a/lib/src/animations/attention_seekers/rubber_band.dart
+++ b/lib/src/animations/attention_seekers/rubber_band.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import '../../types/animate_do_mixins.dart';
 import '../../types/animate_do_types.dart';
 
@@ -11,6 +10,7 @@ class RubberBand extends StatefulWidget {
   final Function(AnimationController)? controller;
   final bool manualTrigger;
   final bool animate;
+  final bool infinite;
   final Function(AnimateDoDirection direction)? onFinish;
   final Curve curve;
 
@@ -22,6 +22,7 @@ class RubberBand extends StatefulWidget {
     this.controller,
     this.manualTrigger = false,
     this.animate = true,
+    this.infinite = false,
     this.onFinish,
     this.curve = Curves.easeOut,
   }) : super(key: key) {
@@ -94,7 +95,7 @@ class RubberBandState extends State<RubberBand>
       delay: widget.delay,
       animate: widget.animate,
       manualTrigger: widget.manualTrigger,
-      infinite: false,
+      infinite: widget.infinite,
       onFinish: widget.onFinish,
       controllerCallback: widget.controller,
     );
@@ -107,7 +108,7 @@ class RubberBandState extends State<RubberBand>
       delay: widget.delay,
       animate: widget.animate,
       manualTrigger: widget.manualTrigger,
-      infinite: false,
+      infinite: widget.infinite,
       onFinish: widget.onFinish,
       controllerCallback: widget.controller,
     );
@@ -143,6 +144,7 @@ extension RubberBandExtension on Widget {
       controller: controller,
       manualTrigger: manualTrigger,
       animate: animate,
+      infinite: infinite,
       onFinish: onFinish,
       curve: curve,
       child: this,


### PR DESCRIPTION
## Description (English)
This PR fixes an issue where the `RubberBand` animation was missing the `infinite` property, causing it to differ from other "Attention Seeker" animations.

**The Issue:**
While other Attention Seeker animations (such as `Bounce`) correctly support the `infinite: true` property, `RubberBand` did not define this parameter in its constructor. Additionally, the logic inside `RubberBandState` had `infinite` hardcoded to `false`, causing the animation to stop after one cycle even if the user intended for it to loop.

**The Fix:**
1. Added `final bool infinite` to the `RubberBand` class and constructor.
2. Updated `configAnimation` and `buildAnimation` in the state to respect the passed `infinite` value instead of using `false`.
3. Updated the `rubberBand` extension method to accept and pass the parameter.

This ensures consistency across all Attention Seeker animations in the package.

---

## Descripción (Español)
Este PR corrige un problema donde la animación `RubberBand` no incluía la propiedad `infinite`, lo que causaba inconsistencia con otras animaciones del tipo "Attention Seeker".

**El Problema:**
Mientras que otras animaciones de "Attention Seeker" (como `Bounce`) soportan correctamente la propiedad `infinite: true`, `RubberBand` no tenía definido este parámetro en su constructor. Además, la lógica dentro de `RubberBandState` tenía el valor `infinite` establecido directamente (hardcoded) en `false`, lo que impedía que la animación se repitiera en bucle.

**La Solución:**
1. Se agregó `final bool infinite` a la clase y al constructor de `RubberBand`.
2. Se actualizaron `configAnimation` y `buildAnimation` en el estado para respetar el valor de `infinite` en lugar de usar `false`.
3. Se actualizó el método de extensión `rubberBand` para aceptar y pasar el parámetro.

Esto asegura la consistencia entre todas las animaciones de tipo Attention Seeker en el paquete.